### PR TITLE
Patches for three problems

### DIFF
--- a/switch-window.el
+++ b/switch-window.el
@@ -175,7 +175,8 @@ ask user for the window where move to"
 	  (switch-to-window-number key))))))
 
 (defadvice other-window (around switch-window-wrapper () activate)
-  (if (< (length (window-list)) 3)
+  (if (or (not (interactive-p))
+	  (< (length (window-list)) 3))
       ad-do-it
     (switch-window)))
 


### PR DESCRIPTION
I wrote three patches to fix the following problems:

(1) An error occurs if term.el isn't loaded prior to switch-window.el
(2) window-point changes when switching to a window displaying the same buffer
(3) 'switch-window-list' returns an incorrectly ordered list in text-only frame

Please check them.
