### PR TITLE
Add a qwerty homekeys layout option for key selection

### DIFF
--- a/switch-window.el
+++ b/switch-window.el
@@ -77,6 +77,10 @@
                  (const :tag "Qwerty Homekeys Layout" 'qwerty))
   :group 'switch-window)
 
+(defcustom switch-window-qwerty-shortcuts '("a" "s" "d" "f" "j" "k" "l" ";" "w" "e" "i" "o")
+  "The list of characters used when switch-window-shortcut-style is 'qwerty'"
+  :group 'switch-window)
+
 (defun switch-window-list-keyboard-keys ()
   "Return a list of current keyboard layout keys"
    (loop with layout = (split-string quail-keyboard-layout "")
@@ -87,7 +91,7 @@
 (defun switch-window-list-keys ()
   "Return a list of keys to use depending on `switch-window-shortcut-style'"
   (cond ((eq switch-window-shortcut-style 'qwerty)
-         '("a" "s" "d" "f" "j" "k" "l" ";" "w" "e" "i" "o"))
+         switch-window-qwerty-shortcuts)
         ((eq switch-window-shortcut-style 'alphabet)
          (loop for i from 0 to 25
                collect (byte-to-string (+ (string-to-char "a") i))))


### PR DESCRIPTION
Instead of 1234 or abcd, for users of qwerty keyboards it seems
reasonable to use the home row keys for choosing different windows to
switch between. Least distance travelled and all that such.

A problem is what to do after reaching the somewhat low limit of 8
homekeys - I elected to add a few more (w, e, i, o) that seemed easy
to reach, but it looks like if I were to have too many windows open,
invoking switch-window just fails. Oh well, I don't often have 12
windows in one frame.

The old options (alphabet and quail) should still work the same as
before, I'm trying to just add a new option. This is an extension of issue
#9, just another choice.
