### PR TITLE
Fix README Links

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -2,8 +2,8 @@
 
 == Window switching, the visual way.
 
-See http://tapoueh.org/emacs/switch-window.html, then install the
-+switch-window.el+ file here (with http://github.com/dimitri/el-get it's
+Check out this http://tapoueh.org/emacs/switch-window.html[screenshot], then install the
++switch-window.el+ file here (with http://github.com/dimitri/el-get[El-Get] it's
 even easier).
 
 == Manual install


### PR DESCRIPTION
So people don't have to delete the trailing comma in the address bar.
