### PR TITLE
Be more friendly to package.el

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -6,9 +6,12 @@ Check out this http://tapoueh.org/emacs/switch-window.html[screenshot], then ins
 +switch-window.el+ file here (with http://github.com/dimitri/el-get[El-Get] or
 https://melpa.milkbox.net[MELPA] it's even easier).
 
-== Manual install
+== Installation
 
-Download the file or +git clone git://github.com/dimitri/el-get.git+ then do
-the following, which will steal your +C-x o+ key:
+Rebind your +C-x o+ key:
+
+  (global-set-key (kbd "C-x o") 'switch-window)
+
+If you do not use El-Get or ELPA, you need to require the package first:
 
   (require 'switch-window)

--- a/switch-window.el
+++ b/switch-window.el
@@ -14,7 +14,8 @@
 ;; Install:
 ;;  (require 'switch-window)
 ;;
-;; It'll take over your C-x o binding.
+;; Rebind your C-x o key:
+;;  (global-set-key (kbd "C-x o") 'switch-window)
 ;;
 ;; Changelog
 ;;
@@ -228,6 +229,5 @@ ask user for the window to select"
 	  (set-window-dedicated-p (car w) (cdr w))))
       key))
 
-(global-set-key (kbd "C-x o") 'switch-window)
 (provide 'switch-window)
 ;;; switch-window.el ends here


### PR DESCRIPTION
Make the interactive commands for autoloading to let package.el load the load the package lazily on first use.

Do not implicitly rebind C-x o to comply with the [Emacs Lisp Coding Conventions](http://www.gnu.org/software/emacs/manual/html_node/elisp/Coding-Conventions.html#Coding-Conventions) which advises against changing the global state by merely loading a package, and to let the user “escape” the package if it was installed unintentionally.
