### PR TITLE
Hide cursor during window selection process.

### DIFF
--- a/switch-window.el
+++ b/switch-window.el
@@ -208,6 +208,7 @@ ask user for the window to select"
     (let ((config (current-window-configuration))
 	  (num 1)
 	  (minibuffer-num nil)
+	  (original-cursor cursor-type)
 	  (eobps (switch-window-list-eobp))
 	  key buffers
 	  window-points
@@ -216,6 +217,8 @@ ask user for the window to select"
       ;; arrange so that C-g will get back to previous window configuration
       (unwind-protect
 	  (progn
+	    ;; hide cursor during window selection process
+	    (setq-default cursor-type nil)
 	    ;; display big numbers to ease window selection
 	    (dolist (win (switch-window-list))
 	      (push (cons win (window-point win)) window-points)
@@ -251,6 +254,8 @@ ask user for the window to select"
 			  (switch-window-restore-eobp eobps)
 			  (keyboard-quit)))))))))
 
+	;; restore original cursor
+	(setq-default cursor-type original-cursor)
 	;; get those huge numbers away
 	(mapc 'kill-buffer buffers)
 	(set-window-configuration config)


### PR DESCRIPTION
First of all, I have to express how much I love this package. Surely one of my most used functions and I couldn't live without it. Thanks for your work on this!

As for the pull-request, I'm not sure if this is something you're interested in so no worries if you'd rather not accept this change, but I started thinking the visual display of the cursor next to the numbers during the window selection process was kind of un-needed and unsightly. Originally I used my own defun to hide the cursor before and after `switch-window`, but thought you may be interested in having this change as part of the package.

Here's a visual example of this change:

![switch-window sans cursors](http://i.imgur.com/AadLC3f.png)

The user's original `cursor-type` is restored after the window configuration is restored.

Thanks again!
