### PR TITLE
inhibit `window-configuration-change-hook' during switch-window

### DIFF
--- a/switch-window.el
+++ b/switch-window.el
@@ -210,6 +210,7 @@ ask user for the window to select"
 	  (minibuffer-num nil)
 	  (original-cursor (default-value 'cursor-type))
 	  (eobps (switch-window-list-eobp))
+         (window-configuration-change-hook nil)
 	  key buffers
 	  window-points
 	  dedicated-windows)


### PR DESCRIPTION
My `window-configuration-change-hook` has a few functions that
apparently run pretty slowly, especially when called twice for each
window I have open - easily up to six or eight times. This
customization option allows the user to decide whether they'd like to
shadow the hook with nil while switch-window is running, and avoid the
unnecessary calls to the -change-hook, especially since the temporary
changes to the window layout that `switch-window` does are hopefully
not pertinent to the functions in `window-configuration-change-hook`.

I don't really like the name of the defcustom I chose, and since it's
so long, it makes the line length stick out in
`prompt-for-selected-window`. And, probably the better solution is for
me to figure out what exactly in my own
`window-configuration-change-hook` is running so slowly. But, I
figured I'd put this PR together in case any one else is experiencing
a significant lag when they invoke `switch-window` and perhaps their
issue is also due to their `window-configuration-change-hook`.