### PR TITLE
Set destination buffer based on default cursor-type.

### DIFF
--- a/switch-window.el
+++ b/switch-window.el
@@ -208,7 +208,7 @@ ask user for the window to select"
     (let ((config (current-window-configuration))
 	  (num 1)
 	  (minibuffer-num nil)
-	  (original-cursor cursor-type)
+	  (original-cursor (default-value 'cursor-type))
 	  (eobps (switch-window-list-eobp))
 	  key buffers
 	  window-points


### PR DESCRIPTION
Following sabof's lead, I made his suggested change and tested it by
comparing the behavior of switching from a `dired' window using
`stripe-buffer-mode' and `stripe-listify-buffer' to another window when
there were 3 windows visible on the frame.

The proposed change preserves the system-wide default of `cursor-type'
even if the starting directory has it's own buffer-local value for
`cursor-type'.