### PR TITLE
Inhibit window-config change hook during switch-window

### DIFF
--- a/switch-window.el
+++ b/switch-window.el
@@ -295,6 +295,7 @@ ask user for the window to select"
         (minibuffer-num nil)
         (original-cursor (default-value 'cursor-type))
         (eobps (switch-window--list-eobp))
+        (window-configuration-change-hook nil)
         key buffers
         window-points
         dedicated-windows)


### PR DESCRIPTION
`other-window` never calls the window-configuration-change-hook, mostly
since it doesn't actually alter the window config. There's no need for
us to call it either, since the changes we're making to the
window-config are only temporary - after deactivating switch-window
mode, we're in the same exact window-config as before.