### PR TITLE
use `figlet' or `banner' to create hint string if runing in terminal

### DIFF
--- a/switch-window.el
+++ b/switch-window.el
@@ -153,29 +153,36 @@ from-current-window is not nil"
     (window-list nil nil (frame-first-window))))
 
 (defcustom switch-window-use-banner-in-term t
-  "Whether to use external utility `banner' to generate big letters,
-which will be used in terminal, to mimic tmux's `display-pane'.
+  "Whether to use external utility `figlet' or `banner' to generate big letters,
+which will be used in terminal to mimic tmux's `display-pane'.
 
 If set to `t', it would be a little slower for the first call of
 `switch-window' in the terminal.")
+
+(defcustom switch-window-banner-program "figlet"
+  "Program use to generate big letters. It could be `figlet', `banner' or
+somthing similar.")
 
 (defvar switch-window--banner-cache (make-hash-table :test 'equal)
   "Cache for big letters of `1', `2', `3'...")
 
 (defun switch-window--insert-banner (label)
   "Insert the banner version of LABEL. If failed, insert LABEL itself."
-  (if (and switch-window-use-banner-in-term
-           (executable-find "banner"))
-      (let ((banner (gethash label switch-window--banner-cache)))
+  (if switch-window-use-banner-in-term
+      (let ((banner (gethash label switch-window--banner-cache))
+            (prg (or (executable-find switch-window-banner-program)
+                     (executable-find "figlet")
+                     (executable-find "banner"))))
         (if banner
             (insert banner)
           ;; not in cache, call `banner' to generate
-          (if (and (= (call-process "banner" nil '(t nil) nil label) 0)
-                   (> (point) 5))
+          (if (and (= (call-process prg nil '(t nil) nil label) 0)
+                   (> (point) 5)) ;; better way?
               ;; put buffer conntent to cache
               (puthash label
                        (buffer-substring (point-min) (point-max))
                        switch-window--banner-cache)
+            ;; fallback
             (insert label))))
     (insert label)))
 
@@ -187,7 +194,8 @@ If set to `t', it would be a little slower for the first call of
     (with-current-buffer buf
       (let ((w (window-width win))
             (h (window-body-height win)))
-        (if (not (display-graphic-p))
+        (if (and (not (display-graphic-p))
+                 (> h 5)) ;; better way?
             (switch-window--insert-banner label)
           (if (fboundp 'text-scale-increase)
               (progn
@@ -199,6 +207,7 @@ If set to `t', it would be a little slower for the first call of
             (insert (propertize label 'face
                                 (list :height (* (* h switch-window-increase)
                                                  (if (> w h) 2 1))))))))
+      (beginning-of-buffer)
       (set-window-buffer win buf)
       buf)))
 

--- a/switch-window.el
+++ b/switch-window.el
@@ -165,10 +165,12 @@ If set to `t', it would be a little slower for the first call of
 (defun switch-window--generate-banners ()
   (message "[switch-window]: Generating banners...")
   (mapc #'(lambda (key)
-            (puthash key
-                     (shell-command-to-string (concat "banner " key))
-                     switch-window--banner-cache))
-        (switch-window--list-keys)))
+            (or (gethash key swith-window--banner-cache)
+                (puthash key
+                         (shell-command-to-string (concat "banner " key))
+                         switch-window--banner-cache)))
+          (switch-window--list-keys))
+  (> (hash-table-count switch-window--banner-cache) 0))
 
 (defun switch-window--display-number (win num)
   "prepare a temp buffer to diplay in the window while choosing"
@@ -181,19 +183,18 @@ If set to `t', it would be a little slower for the first call of
         (if (and (not (display-graphic-p))
                  switch-window-use-banner-in-term
                  (executable-find "banner")
-                 (hash-table-count switch-window--banner-cache))
-                 (switch-window--generate-banners)
+                 (switch-window--generate-banners))
             (insert (gethash label switch-window--banner-cache))
-            (if (fboundp 'text-scale-increase)
-                (progn
-                  ;; increase to maximum switch-window-increase
-                  (text-scale-increase switch-window-increase)
-                  ;; insert the label
-                  (insert label))
-              ;; a hack to support ancient emacs
-              (insert (propertize label 'face
-                                  (list :height (* (* h switch-window-increase)
-                                                   (if (> w h) 2 1))))))))
+          (if (fboundp 'text-scale-increase)
+              (progn
+                ;; increase to maximum switch-window-increase
+                (text-scale-increase switch-window-increase)
+                ;; insert the label
+                (insert label))
+            ;; a hack to support ancient emacs
+            (insert (propertize label 'face
+                                (list :height (* (* h switch-window-increase)
+                                                 (if (> w h) 2 1))))))))
       (set-window-buffer win buf)
       buf)))
 


### PR DESCRIPTION
Hi, dimitri,

I found when working in terminal, the hint string created by `switch-window` seems too small, I improved this by calling external program `figlet` or `banner` to generate a big hint. This would make it a little like tmux's `display-pane`. 

Hope it might be useful to others.