### PR TITLE
Add support for multiple frames (with optional custom frame list function)

### DIFF
--- a/switch-window.el
+++ b/switch-window.el
@@ -405,11 +405,23 @@ It will start at top left unless FROM-CURRENT-WINDOW is not nil"
     (cl-loop for frm in (if relative
                             (cons (selected-frame)
                                   (cl-remove (selected-frame) frames))
-                          frames)
+                          (cl-sort frames
+                                   'switch-window--compare-frame-positions))
              append (window-list frm nil
                                  (unless (and relative
                                               (equal frm (selected-frame)))
                                    (frame-first-window frm))))))
+
+(defun switch-window--compare-frame-positions (frm1 frm2)
+  "Compare positions between two frames FRM1 and FRM2."
+  (cl-destructuring-bind
+      ((x1 . y1) (x2 . y2))
+      (list (frame-position frm1) (frame-position frm2))
+    (cond
+     ((< x1 x2) t)
+     ((> x1 x2) nil)
+     ((< y1 y2) t)
+     (t nil))))
 
 (defun switch-window--display-number (win num)
   "Prepare a temp buffer to diplay NUM in the window WIN while choosing."

--- a/switch-window.el
+++ b/switch-window.el
@@ -360,6 +360,19 @@ increase or decrease window's number, for example:
 ;; Fix warn when compile switch-window with emacs-no-x
 (defvar image-types)
 
+(defcustom switch-window-multiple-frames nil
+  "When non-nil, run `switch-window' across multiple frames."
+  :type 'boolean
+  :group 'switch-window-multiple-frames)
+
+(defcustom switch-window-frame-list-function
+  'visible-frame-list
+  "Function to get a list of frames.
+
+This function is used when `switch-window-multiple-frames' is non-nil."
+  :type 'function
+  :group 'switch-window)
+
 (defun switch-window--list-keyboard-keys ()
   "Return a list of current keyboard layout keys."
   (cl-loop with layout = (split-string quail-keyboard-layout "")
@@ -400,7 +413,7 @@ It will start at top left unless FROM-CURRENT-WINDOW is not nil"
   (let ((relative (or from-current-window
                       switch-window-relative))
         (frames (if (bound-and-true-p switch-window-multiple-frames)
-                    (visible-frame-list)
+                    (funcall switch-window-frame-list-function)
                   (list (selected-frame)))))
     (cl-loop for frm in (if relative
                             (cons (selected-frame)


### PR DESCRIPTION
This implements #15.

To activate it, set `switch-window-multiple-frames` to `t`. 

I also added `switch-window-frame-list-function` option, which can be used to set a frame list function used by the feature. For example, the following configuration allows you to switch to a window chosen from active workspaces in EXWM:

```emacs-lisp
(defun akirak/switch-window-frame-list-function ()
  "Frame list function for `switch-window' on EXWM."
  (cl-remove-if-not #'exwm-workspace--active-p (visible-frame-list)))

(setq switch-window-frame-list-function
        'akirak/switch-window-frame-list-function)
```