### PR TITLE
Fixed typo error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ When switch-window is enabled, user can use the below five keys:
 
 
 <tr>
-<td class="org-left">"k"</td>
+<td class="org-left">"l"</td>
 <td class="org-left">Move the border right</td>
 </tr>
 

--- a/switch-window.el
+++ b/switch-window.el
@@ -60,7 +60,7 @@
 ;; | "i" | Move the border up    |
 ;; | "k" | Move the border down  |
 ;; | "j" | Move the border left  |
-;; | "k" | Move the border right |
+;; | "l" | Move the border right |
 ;; | "b" | Balance windows       |
 ;; |"SPC"| Resume auto-resize    |
 ;;


### PR DESCRIPTION
move the border right should be `l`, not `k`.