### PR TITLE
Explicitly disable show-trailing-whitespace in label buffers

### DIFF
--- a/switch-window.el
+++ b/switch-window.el
@@ -536,6 +536,7 @@ It will start at top left unless FROM-CURRENT-WINDOW is not nil"
     (insert " ")
     (goto-char (point-min))
     (setq-local buffer-read-only t)
+    (setq-local show-trailing-whitespace nil)
     buffer))
 
 (defun switch-window--jump-to-window (index)


### PR DESCRIPTION
If `show-trailing-whitespace` defaults to `t`, it results in distracting highlights in the label buffers. This commit explicitly prevents that.