### PR TITLE
Save and restore windows margins

### DIFF
--- a/switch-window.el
+++ b/switch-window.el
@@ -866,7 +866,7 @@ a window"
         (minibuffer-num nil)
         (num 1)
         key label-buffers
-        window-buffers window-points dedicated-windows)
+        window-buffers window-margins window-points dedicated-windows)
 
     ;; arrange so that C-g will get back to previous window configuration
     (unwind-protect
@@ -877,6 +877,7 @@ a window"
           ;; then display label buffers in all window.
           (dolist (win (switch-window--list))
             (push (cons win (window-buffer win)) window-buffers)
+            (push (cons win (window-margins win)) window-margins)
             (push (cons win (window-point win)) window-points)
             (when (window-dedicated-p win)
               (push (cons win (window-dedicated-p win)) dedicated-windows)
@@ -901,6 +902,9 @@ a window"
       ;; Restore window's buffer, point and dedicate state.
       (dolist (w window-buffers)
         (set-window-buffer (car w) (cdr w) t))
+      ;; Restore window's margins.
+      (dolist (w window-margins)
+        (set-window-margins (car w) (cadr w) (cddr w)))
       (dolist (w window-points)
         (set-window-point (car w) (cdr w)))
       (dolist (w dedicated-windows)

--- a/switch-window.el
+++ b/switch-window.el
@@ -484,7 +484,7 @@ It will start at top left unless FROM-CURRENT-WINDOW is not nil"
                           label (buffer-name (window-buffer win)))))
          (background (switch-window--window-substring win)))
     (funcall switch-window-label-buffer-function win buffer label background)
-    (set-window-buffer win buffer)
+    (set-window-buffer win buffer switch-window-background)
     buffer))
 
 (defun switch-window--window-substring (window)
@@ -654,8 +654,8 @@ TODO: Argument ARG."
     (switch-window)
     (setq buffer2 (current-buffer))
     (setq window2 (get-buffer-window))
-    (set-window-buffer window2 buffer1)
-    (set-window-buffer window1 buffer2)
+    (set-window-buffer window2 buffer1 t)
+    (set-window-buffer window1 buffer2 t)
     (if arg
         (switch-window--select-window window1))))
 
@@ -900,7 +900,7 @@ a window"
       (mapc 'kill-buffer label-buffers)
       ;; Restore window's buffer, point and dedicate state.
       (dolist (w window-buffers)
-        (set-window-buffer (car w) (cdr w)))
+        (set-window-buffer (car w) (cdr w) t))
       (dolist (w window-points)
         (set-window-point (car w) (cdr w)))
       (dolist (w dedicated-windows)

--- a/switch-window.el
+++ b/switch-window.el
@@ -644,20 +644,31 @@ TODO: Argument ARG ."
    #'split-window-right arg 1))
 
 ;;;###autoload
-(defun switch-window-then-swap-buffer (arg)
-  "Select a window then swap its buffer with current window's buffer.
-TODO: Argument ARG."
+(defun switch-window-then-swap-buffer (&optional keep-focus)
+  "Swap the current window's buffer with a selected window's buffer.
+
+Move the focus on the newly selected window unless KEEP-FOCUS is
+non-nil (aka keep the focus on the current window).
+
+When a window is strongly dedicated to its buffer, this function
+won't take effect, and no buffers will be switched."
   (interactive "P")
   (let ((buffer1 (window-buffer))
         (window1 (get-buffer-window))
         buffer2 window2)
-    (switch-window)
-    (setq buffer2 (current-buffer))
-    (setq window2 (get-buffer-window))
-    (set-window-buffer window2 buffer1 t)
-    (set-window-buffer window1 buffer2 t)
-    (if arg
-        (switch-window--select-window window1))))
+    (if (window-dedicated-p window1)
+        (message "The current window has a dedicated buffer: `%s'" (buffer-name buffer1))
+      (switch-window)
+      (setq buffer2 (current-buffer))
+      (setq window2 (get-buffer-window))
+      (if (window-dedicated-p window2)
+          (progn
+            (select-window window1)
+            (message "The selected window has a dedicated buffer: `%s'" (buffer-name buffer2)))
+        (set-window-buffer window2 buffer1 t)
+        (set-window-buffer window1 buffer2 t)
+        (if keep-focus
+            (switch-window--select-window window1))))))
 
 ;;;###autoload
 (defun switch-window-then-find-file ()

--- a/switch-window.el
+++ b/switch-window.el
@@ -311,7 +311,7 @@ of `switch-window-input-style' is 'default ."
   "Auto resize window's size when switch to a window.
 1. If its value is t, auto resize the selected window.
 2. If its value is a function without arguments,
-   when the returned value it non-nil, auto resize
+   when the returned value is non-nil, auto resize
    the selected window."
   :group 'switch-window)
 

--- a/switch-window.el
+++ b/switch-window.el
@@ -645,7 +645,7 @@ TODO: Argument ARG ."
 
 ;;;###autoload
 (defun switch-window-then-swap-buffer (arg)
-  "Select a window then swap it buffer with current window's buffer.
+  "Select a window then swap its buffer with current window's buffer.
 TODO: Argument ARG."
   (interactive "P")
   (let ((buffer1 (window-buffer))


### PR DESCRIPTION
Hello,

After playing a little bit with `set-window-margins` in **Emacs 26.3**, I felt that `switch-window` needs a way to preserve windows margins...

I propose some fixes to handle windows margins, either when they are set manually or programmatically by packages like [perfect-margin](https://github.com/mpwang/perfect-margin).

## Summary

**Also see commit comments.**

- preserve windows margins set programmatically by modes like `perfect-margin-mode`
- preserve windows margins after `switch-window-then-swap-buffer`
- preserve windows margins when a dimmed overlay is applied
- "_save and restore windows margins_" (needed to preserve margins set manually)
- allow `switch-window-then-swap-buffer` to detect dedicated windows (like the [minimap](https://github.com/dengste/minimap))
- fix some typos

The "_save and restore windows margins_" functionality is implemented in `switch-window--prompt`.

When calling `set-window-buffer`, windows margins may be preserved setting `KEEP-MARGINS` to non-nil.

Detecting dedicated windows in `switch-window-then-swap-buffer` allows to not trying to override specialized windows like the one set by `minimap-mode`.

## Notes

When I performed tests with `perfect-margin-mode` on, I set `perfect-margin-visible-width` to 80:
```
(setq perfect-margin-visible-width 80)
```

Also, **I set the Emacs frame big enough** to better visualize the effect of windows margins (**especially to trigger text centering by `perfect-margin-mode`**).

## Details

Below will follow _before (left)_ and _after (right)_ images of what it is expected.

### switch-window-then-swap-buffer

Preserve windows margins set manually:

```
(defun set-custom-margins ()
  (interactive)
  (set-window-margins (selected-window) 20 20))

;; You may use `eval-defun' to evaluate the function `set-custom-margins'.

;; 1. Go in the window 1
;; 2. M-x set-custom-margins
;; 3. M-x switch-window-then-swap-buffer
;; 4. Then choose the window 2
```

Note how in the **Correct** image when calling `set-window-buffer`, windows margins may be preserved setting `KEEP-MARGINS` to non-nil.

#### Wrong: windows margins are not preserved
![00-switch-window-then-swap-buffer_wrong](https://user-images.githubusercontent.com/6450450/89138098-b2096100-d53a-11ea-93a6-06f89435c84f.png)

#### Correct:  windows margins are preserved
![01-switch-window-then-swap-buffer_ok](https://user-images.githubusercontent.com/6450450/89138198-17f5e880-d53b-11ea-895e-bf1f0c273823.png)

### switch-window (switch-window--prompt) and perfect-margin-mode

Preserve windows margins set by [perfect-margin](https://github.com/mpwang/perfect-margin):

```
;; 1. Go in the window 1
;; 2. M-x perfect-margin-mode
;; 3. M-x switch-window
;; 4. Then choose the window 2
```

Note how in the **Correct** image when calling `set-window-buffer`, windows margins set by `perfect-margin-mode` may be preserved setting `KEEP-MARGINS` to non-nil.

#### Wrong: windows margins are not preserved
![02-switch-window--prompt_perfect-margin-mode_wrong](https://user-images.githubusercontent.com/6450450/89139087-eaf70500-d53d-11ea-88a7-9ce0b86dd586.png)

#### Correct: windows margins are preserved
![03-switch-window--prompt_perfect-margin-mode_ok](https://user-images.githubusercontent.com/6450450/89139104-f8ac8a80-d53d-11ea-9390-b0d5c5f782e9.png)

### switch-window (switch-window--prompt)

Save and restore windows margins set manually:

```
(defun set-custom-margins ()
  (interactive)
  (set-window-margins (selected-window) 20 20))

;; You may use `eval-defun` to evaluate the function `set-custom-margins`.

;; 1. Go in the window 1
;; 2. M-x set-custom-margins
;; 3. M-x switch-window
;; 4. Then choose the window 2
```

**Note that setting `set-window-buffer` argument `KEEP-MARGINS` isn't sufficient to save/restore margins set manually.**

#### Wrong: windows margins are not saved/restored
![04-switch-window--prompt_save-restore_wrong](https://user-images.githubusercontent.com/6450450/89139546-483f8600-d53f-11ea-99b7-2411b51a1e9e.png)

#### Correct: windows margins are saved/restored
![05-switch-window--prompt_save-restore_ok](https://user-images.githubusercontent.com/6450450/89139563-57becf00-d53f-11ea-8022-ee53b4d44851.png)

### switch-window-then-swap-buffer and minimap-mode

Do not override dedicated windows like the [minimap](https://github.com/dengste/minimap):

```
;; 1. M-x minimap-mode
;; 2. M-x switch-buffer
;; 3. Go in the window 4
;; 4. M-x switch-buffer
;; 5. Go in the window 1
;; 6. M-x switch-window-then-swap-buffer
;; 7. Then choose the window 2
```

Take a look at the message in the minibuffer of the **Wrong** image: `Window is dedicated to ‘ *MINIMAP*’`.

#### Wrong: trying to override a dedicated window (minimap)
![06-switch-window-then-swap-buffer_dedicated_wrong](https://user-images.githubusercontent.com/6450450/89141163-049b4b00-d544-11ea-8d96-0d394ac84233.png)

#### Correct: detect and do not override a dedicated window (minimap)
![07-switch-window-then-swap-buffer_dedicated_ok](https://user-images.githubusercontent.com/6450450/89141174-0b29c280-d544-11ea-9c86-d6d677898777.png)

### switch-window (switch-window--display-number) and switch-window-background

Preserve windows margins (set manually or by packages like [perfect-margin](https://github.com/mpwang/perfect-margin)) when using dimmed overlays:

```
(defun set-custom-margins ()
  (interactive)
  (set-window-margins (selected-window) 20 20))

;; You may use `eval-defun` to evaluate the function `set-custom-margins`.

;; 1. Either call in the main bigger window:
;;    M-x set-custom-margins
;;    or
;;    M-x perfect-margin-mode
;; 2. M-x eval-expression
;; 3. (setq switch-window-background t)
;; 4. M-x switch-buffer
```

#### Wrong: dimmed overlays do not preserve windows margins
![08-switch-window--display-number_wrong](https://user-images.githubusercontent.com/6450450/89143953-a2931380-d54c-11ea-94bf-fed90d33d0a6.png)

#### Correct: dimmed overlays preserve windows margins
![09-switch-window--display-number_ok](https://user-images.githubusercontent.com/6450450/89143964-aa52b800-d54c-11ea-84c7-91212acd2ac0.png)
