### PR TITLE
Use `window-sap-states' to implement swapping window

### DIFF
--- a/switch-window.el
+++ b/switch-window.el
@@ -222,6 +222,7 @@
 
 (require 'cl-lib)
 (require 'quail)
+(require 'window)
 (require 'switch-window-asciiart)
 (require 'switch-window-mvborder)
 
@@ -690,8 +691,7 @@ won't take effect, and no buffers will be switched."
           (progn
             (select-window window1)
             (message "The selected window has a dedicated buffer: `%s'" (buffer-name buffer2)))
-        (set-window-buffer window2 buffer1 t)
-        (set-window-buffer window1 buffer2 t)
+        (window-swap-states window1 window2)
         (if keep-focus
             (switch-window--select-window window1))))))
 


### PR DESCRIPTION
* switch-window.el: Use `window-swap-states` rather than `set-window-buffer' to avoid only changing buffer but not fringes/margins etc..

The original implementation would cause unexpected behavior if one of the window has enlarged fringe/margin to center the  text. (See [visual fill column](https://codeberg.org/joostkremers/visual-fill-column#centering-the-text).)