### PR TITLE
Fixes switching between invisible windows.

### DIFF
--- a/switch-window.el
+++ b/switch-window.el
@@ -411,8 +411,8 @@ This function is used when `switch-window-multiple-frames' is non-nil."
   "If `switch-window-multiple-frames' is set cycle through all visible
 windows from all frames. Call `other-window' otherwise."
   (if switch-window-multiple-frames
-      (switch-window--select-window (next-window nil nil 'visible))
-    (select-window (next-window nil nil 'visible))))
+      (switch-window--select-window (next-window nil nil "visible"))
+    (select-window (next-window nil nil "visible"))))
 
 (defun switch-window--select-window (window)
   "Switch to the window WINDOW. Select WINDOW's frame respecting


### PR DESCRIPTION
According to the documentation, the fourth parameter of the `next-window` function must be the string `"visible"` to return the next visible window. However, the `'visible` symbol is used. This causes incorrect behavior when the number of visible windows is less than or equal to the threshold. In this case, the visible window is replaced with one of the invisible windows.

Fixes #93 